### PR TITLE
Support tests written as dfns

### DIFF
--- a/APLSource/Core/RunTest.aplf
+++ b/APLSource/Core/RunTest.aplf
@@ -9,7 +9,7 @@
 
  ⎕TRAP←(~cfg.Debug)/(98 'C' '→Fail')((0 1000)'E'((⍕⎕THIS),'.ErrorHandler'))
 
- testspace{⍺.(3.2=42 ⎕ATX ⍵):⍺⍎⍵,'⍬' ⋄ ⍺⍎⍵}testfn
+ testspace{3.2=42 ⍺.⎕ATX ⍵:⍺⍎⍵,'⍬' ⋄ ⍺⍎⍵}testfn
  :Return
 
 Fail:


### PR DESCRIPTION
Problem: All tests are niladic. Right now they are called without any args and therefore does not support dfns.
Solution: Modified the RunTest function to check if test is a dfns, and if so call it with zilde as right argument.

Closes #11