### PR TITLE
Fixed minor errors in documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,13 @@ If you place your tests inside a namespace (e.g., *Tests*) you can pass that nam
 
 ```apl
       Mutsu.RunTests Tests
-Test run on 2024-10-14T15:15:42
-Total suites:   1              
-Total tests:    1              
-Total errors:   0              
-Total failures: 0              
-Total skipped:  0 
+Test run on 2024-10-24T09:34:54
+Total suites:     1            
+Total assertions: 0            
+Total tests:      1            
+Total errors:     0            
+Total failures:   0            
+Total skipped:    0 
 ```
 
 There are three helper functions that you can use inside your tests: `Assert`, `Skip` and `Try`. Calling `Mutsu.RunTests` will 
@@ -29,7 +30,7 @@ place these functions inside your test namespaces before invoking your tests.
 ```apl
 Assert 2=addOne 1 ⍝ Assert that result matches expected value.
 
-Skip 'This test isn't ready yet.'
+Skip 'This test isn''t ready yet.'
 
 2 (11 Try {⍺÷⍵}) 0 ⍝ We expected a Domain error and we got it
 ```

--- a/docs/UsageExamples.md
+++ b/docs/UsageExamples.md
@@ -37,19 +37,19 @@ tests in these two suites and save the test result report as a text file in the 
 follows:
 
 ```apl
-myRunTests; cfg
+myRunTests;cfg
 
 cfg←Mutsu.NewConfiguration
 cfg.TestSpaces←Tests
 cfg.ReportType←Mutsu.REPORTTYPE.TXT
-cfg.ReportPath←'/Users/sandra/Desktop/Result/'
+cfg.ReportPath←'/path/TestReports'
 Mutsu.RunTests cfg
 ```
 
 
 ## Validation helpers
 Mutsu provides three helper functions that you can use in your tests. These functions are copied into any namespace containing 
-test functions when you run `Mutsu.RunTests`.
+test functions when you run `Mutsu.RunTests`, before invoking your tests.
 
 ### Assert
 Use `Assert` to check that the result matches what you expect. `Assert` expects a boolean as the right argument, with 1 indicating 
@@ -65,7 +65,7 @@ Use `Skip` if you have test functions that are not completed yet or not applicab
 want to include them in the test result report.
 
 ```apl
-Skip 'This test isn't ready yet.'
+Skip 'This test isn''t ready yet.'
 ⍝ or
 Skip ('20.0'≡4↑2⊃'.'⎕WG'APLVersion')/'Won''t run on version 20.0'
 


### PR DESCRIPTION
Corrected this in the documentation:
Added double quote in string with quote mark: 'This test isn''t ready yet.'
Updated the example of a test result report in Readme.
Changed example of report path to a general /path/, instead of my specific path.
In UsageExamples, validation helpers section: clarified that the functions will be copied into space before invoking the tests.