### PR TITLE
Try index bug

### DIFF
--- a/APLSource/Core/Try.aplo
+++ b/APLSource/Core/Try.aplo
@@ -1,8 +1,7 @@
- {larg}(err Try rop)rarg;expected;msg;attr_res;attr_val;⎕IO
+ {larg}(err Try rop)rarg;expected;msg;attr_res;attr_val
  ⍝ err: Expected error, either as an event code or a string/substring. 0 if no error expected.
- ⎕IO←0
  expected←{3=10|⎕DR ⍵:⎕EM ⍵ ⋄ ⍵}err
- msg←(err≡0)⊃('Expected exception [',expected,']')'Expected no exception'
+ msg←(⎕IO+err≡0)⊃('Expected exception [',expected,']')'Expected no exception'
  (attr_res attr_val)←10 11⎕ATX'rop'
  ⍎(0=⎕NC'larg')/'larg←⊢'
  :Trap 0

--- a/tasks/BuildAndPublish.aplf
+++ b/tasks/BuildAndPublish.aplf
@@ -1,4 +1,4 @@
- BuildAndPublish;⎕TRAP;⎕IO;⎕ML;root;version;template;ns;json;packagename;parms;api_key;tatin;git_tag; registry
+ BuildAndPublish;⎕TRAP;⎕IO;⎕ML;root;version;packagename;parms;api_key;tatin;git_tag; registry
  ⎕IO←⎕ML←1
  {}⎕EX⊃⎕SI
  ⎕TRAP←0 'E' '⎕←↑⎕DM,⎕XSI,¨''['',¨(⍕¨⎕LC),¨'']'' ⋄ ⎕OFF 1'


### PR DESCRIPTION
The function Try changed IO to 0, it was localised but gave problems when the argument to Try used an index, such as (0 Try{⍵[3]})1 2 3.

Solution: Keep IO as default 1, and instead add an IO-independent pick.
While looking at localised variables: removed unused variables from the header in BuildAndPublish.

Closes #46